### PR TITLE
fix: installation failures on PEP 668-compliant systems

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -35,7 +35,7 @@ if proxy_url is not None:
             sys.exit(1)
         try:
             subprocess.check_call(
-                [sys.executable, '-m', 'pip', 'install', '--cert', './ca-bundle.crt', 'boto3', 'awsiotsdk', 'urllib3>=1.26.7', '--user'])
+                [sys.executable, '-m', 'pip', 'install', '--cert', './ca-bundle.crt', 'boto3', 'awsiotsdk', 'urllib3>=1.26.7', '--user', '--break-system-packages'])
             sys.exit(0)
         except Exception:
             logger.exception(
@@ -46,7 +46,7 @@ if proxy_url is not None:
         logger.info("Installing 'boto3', 'awsiotsdk' and 'urllib3>=1.26.7'")
         try:
             subprocess.check_call(
-                [sys.executable, '-m', 'pip', 'install', 'boto3', 'awsiotsdk', 'urllib3>=1.26.7', '--user'])
+                [sys.executable, '-m', 'pip', 'install', 'boto3', 'awsiotsdk', 'urllib3>=1.26.7', '--user', '--break-system-packages'])
             sys.exit(0)
         except Exception:
             logger.exception(
@@ -55,7 +55,7 @@ if proxy_url is not None:
 
 logger.info("Installing 'boto3' and 'awsiotsdk'")
 try:
-    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'boto3', 'awsiotsdk', '--user'])
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'boto3', 'awsiotsdk', '--user', '--break-system-packages'])
 except Exception:
     logger.exception(
         "Error installing dependencies. Please set 'UseInstaller' to 'False' and pre-install 'boto3' and 'awsiotsdk'")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added --break-system-packages flag to all 3 pip install commands to resolve PEP 668 compatibility issues on newer Linux distributions (Debian Trixie, Ubuntu 24.04+).

**Why is this change necessary:**
Fixes installation failures on PEP 668-compliant systems
Backward compatible with older systems (flag is ignored on non-PEP 668 systems)

**How was this change tested:**
Manually zipped this component and deployed on to Nucleus, component state transited to RUNNING
```
2026-01-30T21:41:46.862Z [INFO] (Copier) aws.greengrass.Cloudwatch: stdout. OutputTopic: cloudwatch/metric/put/status. {scriptName=services.aws.greengrass.Cloudwatch.lifecycle.run.Script, serviceName=aws.greengrass.Cloudwatch, currentState=RUNNING}
2026-01-30T21:41:46.863Z [INFO] (Copier) aws.greengrass.Cloudwatch: stdout. PubSubToIoTCore: false. {scriptName=services.aws.greengrass.Cloudwatch.lifecycle.run.Script, serviceName=aws.greengrass.Cloudwatch, currentState=RUNNING}
```
**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
