### PR TITLE
fix: increase metrics max dimension to 30

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -60,7 +60,7 @@ FIELD_DIMENSION_VALUE = "value"
 FIELD_METRIC_TIMESTAMP = "timestamp"
 FIELD_METRIC_UNIT = "unit"
 
-MAX_DIMENSIONS_PER_METRIC = 10
+MAX_DIMENSIONS_PER_METRIC = 30
 VALID_UNIT_VALUES = {'Seconds', 'Microseconds', 'Milliseconds', 'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes',
                      'Terabytes',
                      'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits', 'Percent', 'Count', 'Bytes/Second',

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -124,10 +124,8 @@ class TestPutMetricRequest(object):
     def test_parse_request_fails_when_dimensions_exceed_limit(self):
         event = self.create_valid_request_with_all_fields()
         new_dimension = {'name': 'new_name', 'value': 'new_value'}
-        event['request']['metricData']['dimensions'].extend([new_dimension, new_dimension, new_dimension,
-                                                             new_dimension, new_dimension, new_dimension,
-                                                             new_dimension, new_dimension, new_dimension,
-                                                             new_dimension])
+        # Base event has 1 dimension, add 30 more to exceed limit of 30
+        event['request']['metricData']['dimensions'].extend([new_dimension] * 30)
 
         with pytest.raises(Exception) as error:
             PutMetricRequest(event)


### PR DESCRIPTION
**Issue #, if available:**
#15 

**Description of changes:**
Cloudwatch supports up to 30 dimensions per metric after August 2022: https://aws.amazon.com/about-aws/whats-new/2022/08/amazon-cloudwatch-metrics-increases-throughput/.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
